### PR TITLE
코드 실행 API 구현

### DIFF
--- a/Dockerfile.java
+++ b/Dockerfile.java
@@ -1,0 +1,5 @@
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+CMD ["sh"]

--- a/src/main/java/com/evenly/evenide/code_runner/controller/CodeExecutionController.java
+++ b/src/main/java/com/evenly/evenide/code_runner/controller/CodeExecutionController.java
@@ -1,0 +1,27 @@
+package com.evenly.evenide.code_runner.controller;
+
+import com.evenly.evenide.code_runner.dto.CodeExecutionRequestDto;
+import com.evenly.evenide.code_runner.dto.CodeExecutionResponse;
+import com.evenly.evenide.code_runner.service.CodeExecutionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/code/execute")
+public class CodeExecutionController {
+
+    private final CodeExecutionService codeExecutionService;
+
+    @PostMapping
+    public ResponseEntity<CodeExecutionResponse> executeCode(
+            @RequestBody CodeExecutionRequestDto requestDto
+    ) throws Exception {
+        CodeExecutionResponse response = codeExecutionService.execute(requestDto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/evenly/evenide/code_runner/dto/CodeExecutionRequestDto.java
+++ b/src/main/java/com/evenly/evenide/code_runner/dto/CodeExecutionRequestDto.java
@@ -1,0 +1,11 @@
+package com.evenly.evenide.code_runner.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CodeExecutionRequestDto {
+    private String language;
+    private String content;
+}

--- a/src/main/java/com/evenly/evenide/code_runner/dto/CodeExecutionResponse.java
+++ b/src/main/java/com/evenly/evenide/code_runner/dto/CodeExecutionResponse.java
@@ -1,0 +1,10 @@
+package com.evenly.evenide.code_runner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CodeExecutionResponse {
+    private String result;
+}

--- a/src/main/java/com/evenly/evenide/code_runner/executor/CodeExecutor.java
+++ b/src/main/java/com/evenly/evenide/code_runner/executor/CodeExecutor.java
@@ -1,0 +1,5 @@
+package com.evenly.evenide.code_runner.executor;
+
+public interface CodeExecutor {
+    String execute(String code) throws Exception;
+}

--- a/src/main/java/com/evenly/evenide/code_runner/executor/JavaExecutor.java
+++ b/src/main/java/com/evenly/evenide/code_runner/executor/JavaExecutor.java
@@ -1,0 +1,41 @@
+package com.evenly.evenide.code_runner.executor;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component("java")
+public class JavaExecutor implements CodeExecutor {
+
+    @Override
+    public String execute(String code) throws Exception {
+        Path tempDir = Files.createTempDirectory("java-run");
+        Path file = tempDir.resolve("Main.java");
+        Files.writeString(file, code);
+
+        // 컴파일 단계
+        ProcessBuilder compileBuilder = new ProcessBuilder(
+                "docker", "run", "--rm",
+                "-v", tempDir.toAbsolutePath() + ":/app",
+                "java-runner", "sh", "-c", "javac /app/Main.java"
+        );
+        compileBuilder.redirectErrorStream(true);
+        Process compileProcess = compileBuilder.start();
+        compileProcess.waitFor(); // 실패 시 처리 가능
+
+        // 실행 단계
+        ProcessBuilder runBuilder = new ProcessBuilder(
+                "docker", "run", "--rm",
+                "-v", tempDir.toAbsolutePath() + ":/app",
+                "java-runner", "sh", "-c", "java -cp /app Main"
+        );
+
+
+        runBuilder.redirectErrorStream(true);
+        Process runProcess = runBuilder.start();
+        String result = new String(runProcess.getInputStream().readAllBytes());
+        runProcess.waitFor();
+        return result;
+    }
+}

--- a/src/main/java/com/evenly/evenide/code_runner/executor/JavaScriptExecutor.java
+++ b/src/main/java/com/evenly/evenide/code_runner/executor/JavaScriptExecutor.java
@@ -1,0 +1,30 @@
+package com.evenly.evenide.code_runner.executor;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component("javascript")
+public class JavaScriptExecutor implements CodeExecutor{
+
+    @Override
+    public String execute(String code) throws Exception {
+        Path tempDir = Files.createTempDirectory("js-run");
+        Path file = tempDir.resolve("script.js");
+        Files.writeString(file, code);
+
+        // 실행 단계
+        ProcessBuilder builder = new ProcessBuilder(
+                "docker", "run", "--rm",
+                "-v", tempDir.toAbsolutePath() + ":/app",
+                "node:20", "node", "/app/script.js"
+        );
+
+        builder.redirectErrorStream(true);
+        Process runProcess = builder.start();
+        String result = new String(runProcess.getInputStream().readAllBytes());
+        runProcess.waitFor();
+        return result;
+    }
+}

--- a/src/main/java/com/evenly/evenide/code_runner/executor/PythonExecutor.java
+++ b/src/main/java/com/evenly/evenide/code_runner/executor/PythonExecutor.java
@@ -1,0 +1,30 @@
+package com.evenly.evenide.code_runner.executor;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component("python")
+public class PythonExecutor implements CodeExecutor {
+
+    @Override
+    public String execute(String code) throws Exception {
+        Path tempDir = Files.createTempDirectory("python-run");
+        Path file = tempDir.resolve("script.py");
+        Files.writeString(file, code);
+
+        // 실행 단계
+        ProcessBuilder builder = new ProcessBuilder(
+                "docker", "run", "--rm",
+                "-v", tempDir.toAbsolutePath() + ":/app",
+                "python:3.12", "python", "/app/script.py"
+        );
+
+        builder.redirectErrorStream(true);
+        Process runProcess = builder.start();
+        String result = new String(runProcess.getInputStream().readAllBytes());
+        runProcess.waitFor();
+        return result;
+    }
+}

--- a/src/main/java/com/evenly/evenide/code_runner/service/CodeExecutionService.java
+++ b/src/main/java/com/evenly/evenide/code_runner/service/CodeExecutionService.java
@@ -1,0 +1,29 @@
+package com.evenly.evenide.code_runner.service;
+
+import com.evenly.evenide.code_runner.dto.CodeExecutionRequestDto;
+import com.evenly.evenide.code_runner.dto.CodeExecutionResponse;
+import com.evenly.evenide.code_runner.executor.CodeExecutor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CodeExecutionService {
+
+    private final Map<String, CodeExecutor> codeExecutorMap;
+
+    public CodeExecutionResponse execute(CodeExecutionRequestDto requestDto) throws Exception {
+        String language = requestDto.getLanguage().toLowerCase();
+
+        CodeExecutor executor = codeExecutorMap.get(language);
+
+        if (executor == null) {
+            throw new IllegalArgumentException("지원하지 않는 언어입니다: " + language);
+        }
+
+        String result = executor.execute(requestDto.getContent());
+        return new CodeExecutionResponse(result);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 코드 실행 API 구현
    - java, js, python 가능

---

## ✨ 주요 변경 사항
- 코드 실행 API 구현
    - java, js, python 가능
    - 8081 포트
- Java 코드 실행 이미지 빌드용 도커 파일
    - js, python은 공식 이미지로 빌드되어 별도 도커파일 없음

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|자바|자바스크립트|파이썬|
|-----|------|------|
|![image](https://github.com/user-attachments/assets/6666a00a-4876-4e5f-b8b1-ca83b802c74c)|![image](https://github.com/user-attachments/assets/165417e8-c645-4077-9ff8-240bab25e126)|![image](https://github.com/user-attachments/assets/47f9f814-40eb-4a2d-bd26-57182e431997)|

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 기능별 예외 케이스 고려 -> 추가 필요
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 💬 기타 참고 사항
- 기존 evenide-back 프로젝트의 스프링이 도커에서 실행되기 때문에, 도커 run으로 코드를 실행시키면 docker in docker 가 되어 보안, 권한, 성능 문제가 있어서 별도의 레포로 서버에 배포 예정입니다.
- 배포 후 스프링은 서버에서 jar로 배포되고 코드 실행은 도커에서 실행됩니다. 
